### PR TITLE
add spec file for rpm-based distributions

### DIFF
--- a/couch_tests.js
+++ b/couch_tests.js
@@ -1,0 +1,108 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// Used by replication test
+if (typeof window == 'undefined' || !window) {
+  CouchDB.host = "127.0.0.1:5984";
+  CouchDB.inBrowser = false;
+} else {
+  CouchDB.host = window.location.host;
+  CouchDB.inBrowser = true;
+}
+
+CouchDB.urlPrefix = "..";
+var couchTests = {};
+
+function loadTest(file) {
+  loadScript("script/test/"+file);
+};
+// keep first
+loadTest("basics.js");
+
+// keep sorted
+loadTest("all_docs.js");
+loadTest("attachment_conflicts.js");
+loadTest("attachment_names.js");
+loadTest("attachment_paths.js");
+loadTest("attachments.js");
+loadTest("attachments_multipart.js");
+loadTest("attachment_views.js");
+loadTest("auth_cache.js");
+loadTest("batch_save.js");
+loadTest("bulk_docs.js");
+loadTest("changes.js");
+loadTest("compact.js");
+loadTest("config.js");
+loadTest("conflicts.js");
+loadTest("content_negotiation.js");
+loadTest("cookie_auth.js");
+loadTest("copy_doc.js");
+loadTest("delayed_commits.js");
+loadTest("design_docs.js");
+loadTest("design_options.js");
+loadTest("design_paths.js");
+loadTest("erlang_views.js");
+loadTest("etags_head.js");
+loadTest("etags_views.js");
+loadTest("form_submit.js");
+loadTest("http.js");
+loadTest("invalid_docids.js");
+loadTest("jsonp.js");
+loadTest("large_docs.js");
+loadTest("list_views.js");
+loadTest("lots_of_docs.js");
+loadTest("method_override.js");
+loadTest("multiple_rows.js");
+loadScript("script/oauth.js");
+loadScript("script/sha1.js");
+loadTest("oauth.js");
+loadTest("proxyauth.js");
+loadTest("purge.js");
+loadTest("reader_acl.js");
+loadTest("recreate_doc.js");
+loadTest("reduce_builtin.js");
+loadTest("reduce_false.js");
+loadTest("reduce_false_temp.js");
+loadTest("reduce.js");
+loadTest("replication.js");
+loadTest("rev_stemming.js");
+loadTest("rewrite.js");
+loadTest("security_validation.js");
+loadTest("show_documents.js");
+loadTest("stats.js");
+loadTest("update_documents.js");
+loadTest("users_db.js");
+loadTest("utf8.js");
+loadTest("uuids.js");
+loadTest("view_collation.js");
+loadTest("view_collation_raw.js");
+loadTest("view_compaction.js");
+loadTest("view_conflicts.js");
+loadTest("view_errors.js");
+loadTest("view_include_docs.js");
+loadTest("view_multi_key_all_docs.js");
+loadTest("view_multi_key_design.js");
+loadTest("view_multi_key_temp.js");
+loadTest("view_offsets.js");
+loadTest("view_pagination.js");
+loadTest("view_sandboxing.js");
+loadTest("view_update_seq.js");
+loadTest("view_xml.js");
+// keep sorted
+
+// geocouch tests
+loadTest("spatial.js");
+loadTest("list_spatial.js");
+loadTest("etags_spatial.js");
+loadTest("multiple_spatial_rows.js");
+loadTest("spatial_compaction.js");
+loadTest("spatial_design_docs.js");

--- a/couchdb-geocouch.spec
+++ b/couchdb-geocouch.spec
@@ -1,0 +1,62 @@
+%define couchdb_user couchdb
+%define couchdb_group couchdb
+%define couchver 1.0.2
+%define couchlib /usr/lib64/erlang/lib/couch-%{couchver}/
+%define couchinc %{couchlib}include/
+%define couchbin %{couchlib}ebin/
+
+%define srcname geocouch
+
+Name:           couchdb-%{srcname}
+Version:        0.1.2
+Release:        2011031001%{?dist}
+Summary:        A spatial index for CouchDB
+
+License:        ASL 2.0
+URL:            https://github.com/couchbase/geocouch
+Source0:        %{srcname}-%{version}.tar.bz2
+
+BuildRequires:  couchdb
+Requires:       couchdb
+
+%description
+GeoCouch is a spatial extension for Apache CouchDB.
+
+
+%prep
+%setup -q -n %{srcname}-%{version}
+
+
+%build
+make %{?_smp_mflags} COUCH_SRC=%{couchinc}
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+make
+
+# install the configuration file
+install -D -m 644 etc/couchdb/local.d/%{srcname}.ini $RPM_BUILD_ROOT%{_sysconfdir}/couchdb/local.d/%{srcname}.ini
+
+# copy the Futon tests
+install -d $RPM_BUILD_ROOT%{_datadir}/couchdb/www/script/test/
+install -D -m 644 share/www/script/test/* $RPM_BUILD_ROOT%{_datadir}/couchdb/www/script/test/
+
+# modify couchdb tests to include these ones too
+install -D -m 644 couch_tests.js $RPM_BUILD_ROOT%{_datadir}/couchdb/www/script/
+
+# compiled beam files
+install -d $RPM_BUILD_ROOT%{couchbin}
+install -D -m 644 build/*.beam $RPM_BUILD_ROOT%{couchbin}
+
+
+%files
+%doc README.md couch_tests.js
+%config(noreplace) %attr(0644, %{couchdb_user}, root) %{_sysconfdir}/couchdb/local.d/%{srcname}.ini
+%{_datadir}/couchdb/www/script/
+%{couchbin}
+
+
+%changelog
+* Thu Jul 21 2011 Pau Aliagas <linuxnow@gmail.com> 0.1.2-2011031001
+- Initial version


### PR DESCRIPTION
I've added a specfile that works for Fedora 15, probably for ther rpm-based systems too.
Source code for couchdb is not needed as the required erh files are installed by default, which makes it much less daunting :)

It would be awesome if the tests could be added in a separate sctipt as I wouldn't have to change the couchdb_tests.js file, but I'm not preficient enough in couchdb to do it. The ideal would be a geocouch_tests.js fle that would appear on futton's menu -hint :)-

I've tested the latest version (couchbase/geocouch) but it does not work with fedora's distributed couchdb-1.0.2
